### PR TITLE
Add Cirrus CI support for Linux/macOS/Windows

### DIFF
--- a/.ci/cargo_install_cache_populate_script.ps1
+++ b/.ci/cargo_install_cache_populate_script.ps1
@@ -1,0 +1,65 @@
+Param(
+    [Switch]
+    $help,
+
+    [Parameter(Mandatory=$True)]
+    [String]
+    $plugin
+)
+
+function Write-Help {
+    Write-Host @"
+$program
+
+Prints latest version of a Cargo crate
+
+USAGE:
+    $program [FLAGS] <CRATE>
+
+FLAGS:
+    -help Prints this message
+
+"@
+}
+
+function main() {
+    $script:program = "cargo_install_cache_populate_script"
+
+    if ($help) {
+        Write-Help
+        exit
+    }
+
+    $root = "$env:CARGO_HOME\opt\$plugin"
+
+    Install-Plugin "$plugin" "$root"
+}
+
+function Install-Plugin {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$True)]
+        [String]
+        $plugin,
+
+        [Parameter(Mandatory=$True)]
+        [String]
+        $root
+    )
+
+    if (-Not (Test-Path "$root")) {
+        New-Item -Type Directory "$root" | Out-Null
+    }
+    cargo install --root "$root" --force --verbose "$plugin"
+
+    # Create symbolic links for all execuatbles into $env:CARGO_HOME\bin
+    Get-ChildItem "$root\bin\*.exe" | ForEach-Object {
+        $dst = "$env:CARGO_HOME\bin\$($_.Name)"
+
+        if (-Not (Test-Path "$dst")) {
+            New-Item -Path "$dst" -Type SymbolicLink -Value "$_" | Out-Null
+        }
+    }
+}
+
+main

--- a/.ci/cargo_install_cache_populate_script.sh
+++ b/.ci/cargo_install_cache_populate_script.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env sh
+# shellcheck shell=sh disable=SC2039
+
+print_usage() {
+  local program="$1"
+
+  echo "$program
+
+    Installs a Cargo plugin into a dedicated directory for later caching
+
+    USAGE:
+        $program [FLAGS] [--] <PLUGIN>
+
+    FLAGS:
+        -h, --help      Prints help information
+
+    ARGS:
+        <PLUGIN>  Name of the Cargo plugin
+    " | sed 's/^ \{1,4\}//g'
+}
+
+main() {
+  set -eu
+  if [ -n "${DEBUG:-}" ]; then set -v; fi
+  if [ -n "${TRACE:-}" ]; then set -xv; fi
+
+  local program
+  program="$(basename "$0")"
+
+  OPTIND=1
+  while getopts "h-:" arg; do
+    case "$arg" in
+      h)
+        print_usage "$program"
+        return 0
+        ;;
+      -)
+        case "$OPTARG" in
+          help)
+            print_usage "$program"
+            return 0
+            ;;
+          '')
+            # "--" terminates argument processing
+            break
+            ;;
+          *)
+            print_usage "$program" >&2
+            fail "invalid argument --$OPTARG"
+            ;;
+        esac
+        ;;
+      \?)
+        print_usage "$program" >&2
+        fail "invalid argument; arg=-$OPTARG"
+        ;;
+    esac
+  done
+  shift "$((OPTIND - 1))"
+
+  if [ -z "${1:-}" ]; then
+    print_usage "$program" >&2
+    fail "missing <PLUGIN> argument; arg=-$OPTARG"
+  fi
+  local plugin="$1"
+  shift
+
+  local root="$CARGO_HOME/opt/$plugin"
+
+  install_plugin "$plugin" "$root"
+}
+
+install_plugin() {
+  local plugin="$1"
+  local root="$2"
+
+  mkdir -p "$root"
+  cargo install --root "$root" --force --verbose "$plugin"
+
+  # Create symbolic links for all execuatbles into $CARGO_HOME/bin
+  ln -snf "$root/bin"/* "$CARGO_HOME/bin/"
+}
+
+fail() {
+  echo "" >&2
+  echo "xxx $1" >&2
+  echo "" >&2
+  return 1
+}
+
+main "$@"

--- a/.ci/crate_version.ps1
+++ b/.ci/crate_version.ps1
@@ -1,0 +1,41 @@
+Param(
+    [Switch]
+    $help,
+
+    [parameter(Position=0)]
+    [String[]]
+    $crate
+)
+
+function Write-Help {
+    Write-Host @"
+$program
+
+Prints latest version of a Cargo crate
+
+USAGE:
+    $program [FLAGS]
+
+FLAGS:
+    -help Prints this message
+
+"@
+}
+
+function main() {
+    $script:program = "crate_version"
+
+    if ($help) {
+        Write-Help
+        exit
+    }
+
+    Get-CrateVersion
+}
+
+function Get-CrateVersion {
+    (cargo search --limit 1 --quiet "$crate" | Select-Object -First 1).
+        Split('"')[1]
+}
+
+main

--- a/.ci/crate_version.sh
+++ b/.ci/crate_version.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+# shellcheck shell=sh disable=SC2039
+
+print_usage() {
+  local program="$1"
+
+  echo "$program
+
+    Prints latest version of a Cargo crate
+
+    USAGE:
+        $program [FLAGS] [--] <CRATE>
+
+    FLAGS:
+        -h, --help      Prints help information
+
+    ARGS:
+        <CRATE>  Name of the Cargo crate
+    " | sed 's/^ \{1,4\}//g'
+}
+
+main() {
+  set -eu
+  if [ -n "${DEBUG:-}" ]; then set -v; fi
+  if [ -n "${TRACE:-}" ]; then set -xv; fi
+
+  local program
+  program="$(basename "$0")"
+
+  OPTIND=1
+  while getopts "h-:" arg; do
+    case "$arg" in
+      h)
+        print_usage "$program"
+        return 0
+        ;;
+      -)
+        case "$OPTARG" in
+          help)
+            print_usage "$program"
+            return 0
+            ;;
+          '')
+            # "--" terminates argument processing
+            break
+            ;;
+          *)
+            print_usage "$program" >&2
+            fail "invalid argument --$OPTARG"
+            ;;
+        esac
+        ;;
+      \?)
+        print_usage "$program" >&2
+        fail "invalid argument; arg=-$OPTARG"
+        ;;
+    esac
+  done
+  shift "$((OPTIND - 1))"
+
+  if [ -z "${1:-}" ]; then
+    print_usage "$program" >&2
+    fail "missing <PLUGIN> argument; arg=-$OPTARG"
+  fi
+  local crate="$1"
+  shift
+
+  report_version "$crate"
+}
+
+report_version() {
+  local crate="$1"
+
+  cargo search --limit 1 --quiet "$crate" | head -n 1 | awk -F'"' '{print $2}'
+}
+
+fail() {
+  echo "" >&2
+  echo "xxx $1" >&2
+  echo "" >&2
+  return 1
+}
+
+main "$@"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,20 +1,126 @@
-container:
-  image: rust:latest
+task:
+  name: check
+  container:
+    image: rust:latest
+  env:
+    RUST_VERSION: stable
 
-check_task:
+  install_rustup_script: |
+    curl -sSfL https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain none --no-modify-path
+  install_rust_script: rustup default "$RUST_VERSION"
+
   cargo_cache:
     folder: $CARGO_HOME/registry
-    fingerprint_script: cat Cargo.lock
-  before_cache_script: rm -rf "$CARGO_HOME/registry/index"
-  install_script:
-    - cargo install cargo-make
-  check_script: cargo make check-flow
+    fingerprint_script: echo "${CIRRUS_OS}"; cat Cargo.lock
 
-test_task:
-  cargo_cache:
-    folder: $CARGO_HOME/registry
-    fingerprint_script: cat Cargo.lock
+  cargo_make_cache:
+    folder: $CARGO_HOME/opt/cargo-make
+    fingerprint_script: |
+      echo "$CIRRUS_OS"
+      echo "$RUST_VERSION"
+      ./.ci/crate_version.sh cargo-make
+    populate_script: ./.ci/cargo_install_cache_populate_script.sh cargo-make
+
   before_cache_script: rm -rf "$CARGO_HOME/registry/index"
-  install_script:
-    - cargo install cargo-make
-  test_script: cargo make ci-flow
+
+  link_plugins_script: ln -snf "$CARGO_HOME"/opt/*/bin/* "$CARGO_HOME"/bin/
+
+  lint_script: cargo "+$RUST_VERSION" make ci-lint-flow
+  format_script: cargo "+$RUST_VERSION" make ci-format-flow
+
+task:
+  env:
+    matrix:
+      - RUST_VERSION: stable
+      - RUST_VERSION: nightly
+      - RUST_VERSION: 1.34.0 # Minimum supported Rust version
+  allow_failures: $RUST_VERSION == 'nightly'
+
+  matrix:
+    - matrix:
+        - name: test_${RUST_VERSION}_linux
+          container:
+            image: rust:latest
+        - name: test_${RUST_VERSION}_macos
+          osx_instance:
+            image: high-sierra-xcode-9.4.1
+          env:
+            CARGO_HOME: "$HOME/.cargo"
+            PATH: "$CARGO_HOME/bin:$PATH"
+
+      install_rustup_script: |
+        curl -sSfL https://sh.rustup.rs \
+          | sh -s -- -y --default-toolchain none --no-modify-path
+      install_rust_script: rustup default "$RUST_VERSION"
+
+      cargo_cache:
+        folder: $CARGO_HOME/registry
+        fingerprint_script: echo "${CIRRUS_OS}"; cat Cargo.lock
+
+      cargo_make_cache:
+        folder: $CARGO_HOME/opt/cargo-make
+        fingerprint_script: |
+          echo "$CIRRUS_OS"
+          echo "$RUST_VERSION"
+          ./.ci/crate_version.sh cargo-make
+        populate_script: ./.ci/cargo_install_cache_populate_script.sh cargo-make
+
+      before_cache_script: rm -rf "$CARGO_HOME/registry/index"
+
+      link_plugins_script: ln -snf "$CARGO_HOME"/opt/*/bin/* "$CARGO_HOME"/bin/
+
+      build_script: cargo "+$RUST_VERSION" make ci-build-flow
+      test_script: cargo "+$RUST_VERSION" make ci-test-flow
+
+    - name: test_${RUST_VERSION}_windows
+      windows_container:
+        image: cirrusci/windowsservercore:cmake
+        os_version: 2019
+      env:
+        CARGO_HOME: $USERPROFILE\.cargo
+        PATH: $CARGO_HOME\bin;$PATH
+
+      install_rustup_script:
+        - ps: |
+            & ([scriptblock]::Create((New-Object System.Net.WebClient).
+              DownloadString('https://gist.github.com/fnichol/699d3c2930649a9932f71bab8a315b31/raw/rustup-init.ps1')
+              )) -y --default-toolchain none --no-modify-path
+      install_rust_script:
+        - ps: rustup default "$env:RUST_VERSION"
+
+      cargo_cache:
+        folder: $CARGO_HOME\registry
+        fingerprint_script:
+          - ps: $env:CIRRUS_OS; Get-Content Cargo.lock
+
+      cargo_make_cache:
+        folder: $CARGO_HOME\opt\cargo-make
+        fingerprint_script:
+          - ps: |
+              $env:CIRRUS_OS
+              $env:RUST_VERSION
+              .\.ci\crate_version.ps1 cargo-make
+        populate_script:
+          - ps: .\.ci\cargo_install_cache_populate_script.ps1 cargo-make
+
+      before_cache_script:
+        - ps: |
+            if (Test-Path "$env:CARGO_HOME\registry\index") {
+              Remove-Item -Recurse -Force "$env:CARGO_HOME\registry\index"
+            }
+
+      link_plugins_script:
+        - ps: |
+            Get-ChildItem "$env:CARGO_HOME\opt\*\bin\*.exe" | ForEach-Object {
+              $dst = "$env:CARGO_HOME\bin\$($_.Name)"
+
+              if (-Not (Test-Path "$dst")) {
+                New-Item -Path "$dst" -Type SymbolicLink -Value "$_" | Out-Null
+              }
+            }
+
+      build_script:
+        - ps: cargo "+$env:RUST_VERSION" make ci-build-flow
+      test_script:
+        - ps: cargo "+$env:RUST_VERSION" make ci-test-flow

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,11 +1,44 @@
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = "true"
 
-[tasks.check]
-description = "Checks all linting, styling, & other rules"
+[tasks.ci-lint-flow]
+description = "CI task runs cargo clippy"
+category = "CI"
 dependencies = [
   "clippy",
-  "check-format"
+]
+
+[tasks.ci-format-flow]
+description = "CI task runs cargo fmt with check"
+category = "CI"
+dependencies = [
+  "check-format",
+]
+
+[tasks.ci-check-flow]
+description = "Checks all linting, styling, & other rules"
+category = "CI"
+dependencies = [
+  "ci-lint-flow",
+  "ci-format-flow"
+]
+
+[tasks.ci-build-flow]
+description = "CI task runs cargo build with verbose output"
+category = "CI"
+dependencies = [
+  "pre-build",
+  "build-verbose",
+  "post-build",
+]
+
+[tasks.ci-test-flow]
+description = "CI task runs cargo test with verbose output"
+category = "CI"
+dependencies = [
+  "pre-test",
+  "test-verbose",
+  "post-test",
 ]
 
 [tasks.check-format]


### PR DESCRIPTION
This change (which I'm pretty excited about) adds continuous integration
backed by Cirrus CI to the project. Linux, macOS, and Windows platforms
are supported for builds and tests across latest stable and nightly Rust
versions and a dedicated job for "checking" (i.e. Formatting and
linting) is provided to separate the "does it work" from "is the
formatting consistent".

This project is using the [cargo-make] Cargo plugin for consistent,
cross platform workflows and the plugin itself is cached between CI runs
for greater execution speed.

Note that while the YAML description is rather long and nontrivial, it
is extremely effective and can be used/adapted/copied into future
projects with all the benefit. In short: it was very well worth the
effort getting this to work.

[cargo-make]: https://sagiegurari.github.io/cargo-make/