### PR TITLE
Address lints

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -54,6 +54,9 @@ args = [
   "clippy",
   "--all-targets",
   "--all-features",
+  "--",
+  "-D",
+  "warnings",
 ]
 
 [tasks.readme]

--- a/mtoc/src/main.rs
+++ b/mtoc/src/main.rs
@@ -59,16 +59,17 @@ fn try_main() -> Result<()> {
 
     match args.output() {
         Some(output) => write_to_file(builder, output),
-        None => match args.is_in_place() {
-            true => {
+        None => {
+            if args.is_in_place() {
                 debug!("writing in-place");
                 match args.input() {
                     Some(input) => write_to_file(builder, input),
                     None => write_to_stdout(builder),
                 }
+            } else {
+                write_to_stdout(builder)
             }
-            false => write_to_stdout(builder),
-        },
+        }
     }
 }
 

--- a/mtoc/src/util.rs
+++ b/mtoc/src/util.rs
@@ -76,19 +76,16 @@ pub(crate) fn setup_panic_hooks() {
 
     let default_hook = panic::take_hook();
 
-    match env::var("RUST_BACKTRACE") {
-        Err(_) => {
-            panic::set_hook(Box::new(move |info: &panic::PanicInfo| {
-                // First call the default hook that prints to standard error
-                default_hook(info);
+    if env::var("RUST_BACKTRACE").is_err() {
+        panic::set_hook(Box::new(move |info: &panic::PanicInfo| {
+            // First call the default hook that prints to standard error
+            default_hook(info);
 
-                // Then call human_panic
-                let file_path = human_panic::handle_dump(&meta, info);
-                human_panic::print_msg(file_path, &meta)
-                    .expect("human-panic: printing error message to console failed");
-            }));
-        }
-        Ok(_) => {}
+            // Then call human_panic
+            let file_path = human_panic::handle_dump(&meta, info);
+            human_panic::print_msg(file_path, &meta)
+                .expect("human-panic: printing error message to console failed");
+        }));
     }
 }
 


### PR DESCRIPTION
This changeset fixes up some Clippy suggestions and also enables a fail-on-warnings behavior in the `check` CI task.