### PR TITLE
[mtoc] Add check mode for a CI context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +410,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1187,6 +1193,7 @@ dependencies = [
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf3720d3f3fc30b721ef1ae54e13af3264af4af39dc476a8de56a6ee1e2184b"
+"checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"

--- a/mtoc/Cargo.toml
+++ b/mtoc/Cargo.toml
@@ -21,6 +21,7 @@ human-panic = "1.0.1"
 log = "0.4.6"
 mtoc-parser = { path = "../mtoc-parser" }
 structopt = { version = "0.2.16", default-features = false, features = ["suggestions", "wrap_help"] }
+diff = "0.1.11"
 
 [dev-dependencies]
 assert_cmd = "0.11.1"

--- a/mtoc/src/check.rs
+++ b/mtoc/src/check.rs
@@ -1,0 +1,252 @@
+// Copyright 2019 Fletcher Nichol and/or applicable contributors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license (see <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or
+// distributed except according to those terms.
+
+//! A module to compute and display the textural differences between two sources.
+//!
+//! This implementation was taken, adapted, and simplified from the Rustfmt project's
+//! `rustfmt_diff` module. Rustfmt is dual licensed under the Apache v2 license and the MIT
+//! license.
+//!
+//! Source:
+//! * https://github.com/rust-lang/rustfmt
+//! * https://git.io/fjrwX
+use crate::Result;
+use std::collections::VecDeque;
+use std::fmt::Display;
+use std::io::Write;
+
+/// Represents a comparison line between two sources.
+#[derive(Debug, PartialEq)]
+enum DiffLine {
+    Context(String),
+    Expected(String),
+    Resulting(String),
+}
+
+/// Represents a contiguous collection of lines that differ between two sources.
+#[derive(Debug, PartialEq)]
+struct Mismatch {
+    line_number_orig: u32,
+    lines: Vec<DiffLine>,
+}
+
+impl Mismatch {
+    /// Builds and returns a new instance.
+    fn new(line_number_orig: u32) -> Mismatch {
+        Mismatch {
+            line_number_orig,
+            lines: Vec::new(),
+        }
+    }
+}
+
+/// Writes a diff-like report to a 'writer' between two sources.
+pub(crate) fn write_diff<D, W>(
+    expected: &str,
+    actual: &str,
+    source: D,
+    writer: &mut W,
+) -> Result<()>
+where
+    D: Display,
+    W: Write,
+{
+    let diff = make_diff(expected, actual, 3);
+
+    for mismatch in diff {
+        writeln!(
+            writer,
+            "Diff in {} at line {}:",
+            source, mismatch.line_number_orig
+        )?;
+
+        for line in mismatch.lines {
+            match line {
+                DiffLine::Context(ref str) => {
+                    writeln!(writer, " {}", str)?;
+                }
+                DiffLine::Expected(ref str) => {
+                    writeln!(writer, "+{}", str)?;
+                }
+                DiffLine::Resulting(ref str) => {
+                    writeln!(writer, "-{}", str)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Builds a list of contiguous mismatching lines between two sources.
+fn make_diff(expected: &str, actual: &str, context_size: usize) -> Vec<Mismatch> {
+    let mut line_number_orig = 1;
+    let mut context_queue: VecDeque<&str> = VecDeque::with_capacity(context_size);
+    let mut lines_since_mismatch = context_size + 1;
+    let mut results = Vec::new();
+    let mut mismatch = Mismatch::new(0);
+
+    for result in diff::lines(expected, actual) {
+        match result {
+            diff::Result::Left(str) => {
+                if lines_since_mismatch >= context_size && lines_since_mismatch > 0 {
+                    results.push(mismatch);
+                    mismatch = Mismatch::new(line_number_orig - context_queue.len() as u32);
+                }
+
+                while let Some(line) = context_queue.pop_front() {
+                    mismatch.lines.push(DiffLine::Context(line.to_owned()));
+                }
+
+                mismatch.lines.push(DiffLine::Resulting(str.to_owned()));
+                line_number_orig += 1;
+                lines_since_mismatch = 0;
+            }
+            diff::Result::Right(str) => {
+                if lines_since_mismatch >= context_size && lines_since_mismatch > 0 {
+                    results.push(mismatch);
+                    mismatch = Mismatch::new(line_number_orig - context_queue.len() as u32);
+                }
+
+                while let Some(line) = context_queue.pop_front() {
+                    mismatch.lines.push(DiffLine::Context(line.to_owned()));
+                }
+
+                mismatch.lines.push(DiffLine::Expected(str.to_owned()));
+                lines_since_mismatch = 0;
+            }
+            diff::Result::Both(str, _) => {
+                if context_queue.len() >= context_size {
+                    let _ = context_queue.pop_front();
+                }
+
+                if lines_since_mismatch < context_size {
+                    mismatch.lines.push(DiffLine::Context(str.to_owned()));
+                } else if context_size > 0 {
+                    context_queue.push_back(str);
+                }
+
+                line_number_orig += 1;
+                lines_since_mismatch += 1;
+            }
+        }
+    }
+
+    results.push(mismatch);
+    results.remove(0);
+
+    results
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use DiffLine::*;
+
+    #[test]
+    fn make_diff_simple() {
+        let src = "one\ntwo\nthree\nfour\nfive\n";
+        let dst = "one\ntwo\ntrois\nfour\nfive\n";
+        let diff = make_diff(src, dst, 1);
+
+        assert_eq!(
+            diff,
+            vec![Mismatch {
+                line_number_orig: 2,
+                lines: vec![
+                    Context("two".to_owned()),
+                    Resulting("three".to_owned()),
+                    Expected("trois".to_owned()),
+                    Context("four".to_owned()),
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn make_diff_simple2() {
+        let src = "one\ntwo\nthree\nfour\nfive\nsix\nseven\n";
+        let dst = "one\ntwo\ntrois\nfour\ncinq\nsix\nseven\n";
+        let diff = make_diff(src, dst, 1);
+
+        assert_eq!(
+            diff,
+            vec![
+                Mismatch {
+                    line_number_orig: 2,
+                    lines: vec![
+                        Context("two".to_owned()),
+                        Resulting("three".to_owned()),
+                        Expected("trois".to_owned()),
+                        Context("four".to_owned()),
+                    ],
+                },
+                Mismatch {
+                    line_number_orig: 5,
+                    lines: vec![
+                        Resulting("five".to_owned()),
+                        Expected("cinq".to_owned()),
+                        Context("six".to_owned()),
+                    ],
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn make_diff_zerocontext() {
+        let src = "one\ntwo\nthree\nfour\nfive\n";
+        let dst = "one\ntwo\ntrois\nfour\nfive\n";
+        let diff = make_diff(src, dst, 0);
+
+        assert_eq!(
+            diff,
+            vec![Mismatch {
+                line_number_orig: 3,
+                lines: vec![Resulting("three".to_owned()), Expected("trois".to_owned())],
+            }]
+        );
+    }
+
+    #[test]
+    fn make_diff_trailing_newline() {
+        let src = "one\ntwo\nthree\nfour\nfive";
+        let dst = "one\ntwo\nthree\nfour\nfive\n";
+        let diff = make_diff(src, dst, 1);
+
+        assert_eq!(
+            diff,
+            vec![Mismatch {
+                line_number_orig: 5,
+                lines: vec![Context("five".to_owned()), Expected("".to_owned())],
+            }]
+        );
+    }
+
+    #[test]
+    fn write_diff_simple() {
+        let src = "one\ntwo\nthree\nfour\nfive\n";
+        let dst = "one\ntwo\ntrois\nfour\nfive\n";
+        let mut buf = Vec::new();
+
+        write_diff(src, dst, "<src>", &mut buf).unwrap();
+
+        assert_eq!(
+            "\
+Diff in <src> at line 1:
+ one
+ two
+-three
++trois
+ four
+ five
+ 
+",
+            std::str::from_utf8(&buf).unwrap()
+        );
+    }
+}

--- a/mtoc/tests/fixtures/simple-current.md
+++ b/mtoc/tests/fixtures/simple-current.md
@@ -1,0 +1,24 @@
+# Title
+
+<!-- toc -->
+
+- [Introduction](#introduction)
+- [Body](#body)
+  * [Detail](#detail)
+- [Conclusion](#conclusion)
+
+<!-- tocstop -->
+
+## Introduction
+
+Introduction content.
+
+## Body
+
+### Detail
+
+Cool detail.
+
+## Conclusion
+
+Concluding remarks.


### PR DESCRIPTION
This change adds a `-c/--check` flag to the CLI which runs the program
in "check mode" which will exit `0` if running the program in normal
mode would not change the contents of the input and exit `1` with a diff
otherwise. This is intended for CI systems.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>